### PR TITLE
chore(release): iOS expo config, update version

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "name": "cKash",
   "slug": "ckash",
   "scheme": "ckash",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "orientation": "portrait",
   "icon": "./assets/icon.png",
   "userInterfaceStyle": "light",

--- a/eas.json
+++ b/eas.json
@@ -18,5 +18,12 @@
       "autoIncrement": true,
       "distribution": "store"
     }
+  },
+  "submit": {
+    "production": {
+      "ios": {
+        "ascAppId": "6738967491"
+      }
+    }
   }
 }


### PR DESCRIPTION
For the time being, we're releasing the Divvi framework version of ckash on the existing Mento app within our own Apple developer account. This tells Expo which app to publish builds to. Since we've already released 1.xx versions, setting the starting version to 2.0.0 as well.